### PR TITLE
话说转换成Svg组件后 属性名应该改成驼峰的写法

### DIFF
--- a/src/libs/generateComponent.ts
+++ b/src/libs/generateComponent.ts
@@ -172,7 +172,10 @@ const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['pa
         template += `\n${whitespace(counter.baseIdent + 4)}${attributeName}={getIconColor(color, ${counter.colorIndex}, '${sub.$[attributeName]}')}`;
         counter.colorIndex += 1;
       } else {
-        template += `\n${whitespace(counter.baseIdent + 4)}${attributeName}="${sub.$[attributeName]}"`;
+        // convert attribute name to camel case, e.g fill-opacity to fillOpacity
+        const reg = /-(\w)/g;
+        const camelAttributeName = attributeName.replace(reg, (a,b) =>  b.toUpperCase());
+        template += `\n${whitespace(counter.baseIdent + 4)}${camelAttributeName}="${sub.$[attributeName]}"`;
       }
     }
   }

--- a/src/libs/generateComponent.ts
+++ b/src/libs/generateComponent.ts
@@ -174,7 +174,7 @@ const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['pa
       } else {
         // convert attribute name to camel case, e.g fill-opacity to fillOpacity
         const reg = /-(\w)/g;
-        const camelAttributeName = attributeName.replace(reg, (a,b) =>  b.toUpperCase());
+        const camelAttributeName = attributeName.replace(reg, (_a,b) =>  b.toUpperCase());
         template += `\n${whitespace(counter.baseIdent + 4)}${camelAttributeName}="${sub.$[attributeName]}"`;
       }
     }


### PR DESCRIPTION

比如：
`
fill-opacity=".3" => 
fillOpacity=".3"
`